### PR TITLE
Fixed compatibility with Carpet.

### DIFF
--- a/src/main/java/retr0/itemfavorites/mixin/MixinScreenHandler.java
+++ b/src/main/java/retr0/itemfavorites/mixin/MixinScreenHandler.java
@@ -49,8 +49,9 @@ public abstract class MixinScreenHandler {
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/screen/slot/Slot;getMaxItemCount(Lnet/minecraft/item/ItemStack;)I",
-            ordinal = 0),
-        index = 0)
+            ordinal = 0
+        )
+    )
     private ItemStack suppressFavoriteStatus(ItemStack itemStack) {
         var targetSlotFavoriteStatus = ExtensionItemStack.isFavorite(quickCraftSlot.getStack());
 


### PR DESCRIPTION
This allows the ModifyArgInjector to stack with the Carpet redirect on Slot#getMaxItemCount(ItemStack).